### PR TITLE
Improve onboarding UX: CLI flags, non-interactive install, security hardening, quickstart profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # 4. Test: curl -X POST "https://api.telegram.org/bot<TOKEN>/sendMessage" \
 #           -d "chat_id=<CHAT_ID>" -d "text=Test"
 #
-# Full guide: https://github.com/yourusername/telemon#step-1-create-a-bot
+# Full guide: https://github.com/SwordfishTrumpet/telemon#step-1-create-a-bot
 # -----------------------------------------------------------------------------
 TELEGRAM_BOT_TOKEN="your-bot-token-here"
 TELEGRAM_CHAT_ID="your-chat-id-here"
@@ -96,8 +96,9 @@ CRITICAL_SYSTEM_PROCESSES="sshd"
 
 # -----------------------------------------------------------------------------
 # Critical Docker Containers
-# These are checked via `docker ps`
-# Space-separated list of container names - empty string disables this check
+# These are checked via `docker ps` — use container NAMES, not image names.
+# Find your container names with: docker ps --format '{{.Names}}'
+# Space-separated list - empty string disables this check
 # Example: "postgres redis nginx"
 # -----------------------------------------------------------------------------
 CRITICAL_CONTAINERS=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CLI flags for `telemon.sh`: `--test` / `-t` (validate + send test Telegram message), `--validate` / `-v` (check config without sending), `--help` / `-h`
+- `install.sh`: `--yes` / `-y` flag for non-interactive installs (CI, scripting, automation)
+- `install.sh`: automatically sets `.env` to `chmod 600` (owner-only) to protect bot tokens
+- `.env.example`: clarified that `CRITICAL_CONTAINERS` uses container names from `docker ps --format '{{.Names}}'`, not image names
+- `README.md`: "Common Configurations" section with copy-paste `.env` quickstart profiles for Docker host, web server, media server, bare metal, and Node.js setups
 - Uninstall script (`uninstall.sh`) for clean removal
 - Update mechanism (`update.sh`) with git integration
 - Administration utility (`telemon-admin.sh`) for backup/restore/status
@@ -64,5 +69,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .env.example with all configuration options
 - MIT License
 
-[Unreleased]: https://github.com/yourusername/telemon/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/yourusername/telemon/releases/tag/v1.0.0
+[Unreleased]: https://github.com/SwordfishTrumpet/telemon/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/SwordfishTrumpet/telemon/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -95,6 +95,82 @@ CRITICAL_PM2_PROCESSES="hound"
 CRITICAL_SITES=""              # URLs to monitor, e.g., "https://example.com"
 ```
 
+### Common Configurations
+
+Copy-paste these `.env` snippets as starting points for common setups:
+
+<details>
+<summary><strong>Docker Host</strong> (Proxmox, NAS, home server)</summary>
+
+```bash
+ENABLE_DOCKER_CONTAINERS=true
+ENABLE_PM2_PROCESSES=false
+ENABLE_SITE_MONITOR=false
+CRITICAL_SYSTEM_PROCESSES="sshd dockerd"
+CRITICAL_CONTAINERS="postgres redis nginx"   # use container names from: docker ps --format '{{.Names}}'
+```
+
+</details>
+
+<details>
+<summary><strong>Web Server</strong> (Nginx/Apache + SSL)</summary>
+
+```bash
+ENABLE_DOCKER_CONTAINERS=false
+ENABLE_PM2_PROCESSES=false
+ENABLE_SITE_MONITOR=true
+SITE_CHECK_SSL=true
+SITE_SSL_WARN_DAYS=14
+CRITICAL_SYSTEM_PROCESSES="sshd nginx"
+CRITICAL_SITES="https://example.com|max_response_ms=5000 https://api.example.com|expected_status=200"
+```
+
+</details>
+
+<details>
+<summary><strong>Media Server</strong> (Plex/Jellyfin + rclone/mergerfs)</summary>
+
+```bash
+ENABLE_DOCKER_CONTAINERS=true
+ENABLE_PM2_PROCESSES=false
+ENABLE_SITE_MONITOR=true
+CRITICAL_SYSTEM_PROCESSES="sshd cron"
+CRITICAL_CONTAINERS="plex zurg"              # use container names from: docker ps --format '{{.Names}}'
+CRITICAL_SITES="http://localhost:32400/identity http://localhost:9999/dav/version.txt"
+SITE_EXPECTED_STATUS=200
+DISK_THRESHOLD_WARN=85
+DISK_THRESHOLD_CRIT=90
+```
+
+</details>
+
+<details>
+<summary><strong>Bare Metal / VPS</strong> (no Docker, no PM2)</summary>
+
+```bash
+ENABLE_DOCKER_CONTAINERS=false
+ENABLE_PM2_PROCESSES=false
+ENABLE_SITE_MONITOR=false
+CRITICAL_SYSTEM_PROCESSES="sshd cron"
+CRITICAL_CONTAINERS=""
+```
+
+</details>
+
+<details>
+<summary><strong>Node.js App Server</strong> (PM2-managed)</summary>
+
+```bash
+ENABLE_DOCKER_CONTAINERS=false
+ENABLE_PM2_PROCESSES=true
+ENABLE_SITE_MONITOR=true
+CRITICAL_SYSTEM_PROCESSES="sshd"
+CRITICAL_PM2_PROCESSES="api worker scheduler"
+CRITICAL_SITES="https://api.example.com|max_response_ms=3000"
+```
+
+</details>
+
 ### Disabling Checks
 
 **To disable a specific check**, set its `ENABLE_` variable to `false`:
@@ -265,6 +341,12 @@ container_postgres=OK:0
 # Run check manually
 bash telemon.sh
 
+# Validate configuration (checks credentials, permissions, dependencies)
+bash telemon.sh --validate
+
+# Send a test message (validates config + sends Telegram test)
+bash telemon.sh --test
+
 # View logs
 tail -f telemon.log
 tail -f telemon_cron.log
@@ -419,7 +501,8 @@ See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for detailed troubleshoot
 
 | Problem | Quick Solution |
 |---------|---------------|
-| No alerts received? | Run `bash telemon-admin.sh validate` to check config |
+| No alerts received? | Run `bash telemon.sh --validate` to check config |
+| Telegram not working? | Run `bash telemon.sh --test` to send a test message |
 | False alarms? | Increase `CONFIRMATION_COUNT` in `.env` |
 | Docker checks failing? | Add user to docker group: `sudo usermod -aG docker $USER` |
 | State stuck? | Run `bash telemon-admin.sh reset-state` |

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONITOR_SCRIPT="${SCRIPT_DIR}/telemon.sh"
 CRON_SCHEDULE="*/5 * * * *"
 
+# Parse flags
+AUTO_YES=false
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes) AUTO_YES=true ;;
+        -h|--help)
+            echo "Usage: bash install.sh [--yes|-y]"
+            echo ""
+            echo "Options:"
+            echo "  -y, --yes    Non-interactive mode: skip prompts, run test automatically"
+            exit 0
+            ;;
+    esac
+done
+
 # Use flock in cron if available to prevent overlapping runs
 if command -v flock &>/dev/null; then
     LOCK_FILE="/tmp/telemon_sys_alert_state.lock"
@@ -54,6 +69,15 @@ if [[ ! -f "${SCRIPT_DIR}/.env" ]]; then
     exit 1
 fi
 echo "  .env found."
+
+# Secure .env file permissions (contains Telegram bot token)
+local_perms=$(stat -c '%a' "${SCRIPT_DIR}/.env" 2>/dev/null || stat -f '%Lp' "${SCRIPT_DIR}/.env" 2>/dev/null)
+if [[ "$local_perms" != "600" ]]; then
+    chmod 600 "${SCRIPT_DIR}/.env"
+    echo "  .env permissions set to 600 (owner-only read/write)."
+else
+    echo "  .env permissions OK (600)."
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Make script executable
@@ -157,8 +181,13 @@ echo "[7/7] Running initial test..."
 echo "  This will execute a full check cycle. On first run, all metrics"
 echo "  will be treated as NEW and you'll receive a Telegram message."
 echo ""
-read -rp "  Run test now? [Y/n] " answer
-answer="${answer:-Y}"
+
+if [[ "$AUTO_YES" == "true" ]]; then
+    answer="Y"
+else
+    read -rp "  Run test now? [Y/n] " answer
+    answer="${answer:-Y}"
+fi
 
 if [[ "$answer" =~ ^[Yy]$ ]]; then
     echo ""

--- a/telemon.sh
+++ b/telemon.sh
@@ -943,6 +943,187 @@ check_sites() {
 }
 
 # ===========================================================================
+# CLI Modes: --test, --validate
+# ===========================================================================
+run_validate() {
+    echo "Telemon configuration validation"
+    echo "================================="
+    echo ""
+    
+    local errors=0
+    local warnings=0
+    
+    # Check Telegram credentials
+    echo "[Telegram Credentials]"
+    if [[ -z "${TELEGRAM_BOT_TOKEN:-}" || "$TELEGRAM_BOT_TOKEN" == "your-bot-token-here" ]]; then
+        echo "  FAIL: TELEGRAM_BOT_TOKEN is not set"
+        errors=$((errors + 1))
+    else
+        echo "  OK:   TELEGRAM_BOT_TOKEN is set (${TELEGRAM_BOT_TOKEN:0:10}...)"
+    fi
+    
+    if [[ -z "${TELEGRAM_CHAT_ID:-}" || "$TELEGRAM_CHAT_ID" == "your-chat-id-here" ]]; then
+        echo "  FAIL: TELEGRAM_CHAT_ID is not set"
+        errors=$((errors + 1))
+    else
+        echo "  OK:   TELEGRAM_CHAT_ID is set ($TELEGRAM_CHAT_ID)"
+    fi
+    
+    # Check .env permissions
+    echo ""
+    echo "[Security]"
+    local env_perms
+    env_perms=$(stat -c '%a' "$ENV_FILE" 2>/dev/null || stat -f '%Lp' "$ENV_FILE" 2>/dev/null)
+    if [[ "$env_perms" != "600" ]]; then
+        echo "  WARN: .env permissions are $env_perms (should be 600)"
+        echo "        Fix: chmod 600 $ENV_FILE"
+        warnings=$((warnings + 1))
+    else
+        echo "  OK:   .env permissions are 600 (owner-only)"
+    fi
+    
+    # Check enabled features and their dependencies
+    echo ""
+    echo "[Enabled Checks]"
+    local enabled=0
+    for check in CPU MEMORY DISK SWAP IOWAIT ZOMBIE INTERNET; do
+        local var="ENABLE_${check}_CHECK"
+        if [[ "${!var:-true}" == "true" ]]; then
+            echo "  ON:   $check"
+            enabled=$((enabled + 1))
+        else
+            echo "  OFF:  $check"
+        fi
+    done
+    
+    if [[ "${ENABLE_SYSTEM_PROCESSES:-true}" == "true" ]]; then
+        echo "  ON:   SYSTEM_PROCESSES (${CRITICAL_SYSTEM_PROCESSES:-<empty>})"
+        enabled=$((enabled + 1))
+    else
+        echo "  OFF:  SYSTEM_PROCESSES"
+    fi
+    
+    if [[ "${ENABLE_FAILED_SYSTEMD_SERVICES:-true}" == "true" ]]; then
+        if ! command -v systemctl &>/dev/null; then
+            echo "  WARN: FAILED_SYSTEMD_SERVICES enabled but systemctl not found"
+            warnings=$((warnings + 1))
+        else
+            echo "  ON:   FAILED_SYSTEMD_SERVICES"
+            enabled=$((enabled + 1))
+        fi
+    else
+        echo "  OFF:  FAILED_SYSTEMD_SERVICES"
+    fi
+    
+    if [[ "${ENABLE_DOCKER_CONTAINERS:-false}" == "true" ]]; then
+        if ! command -v docker &>/dev/null; then
+            echo "  FAIL: DOCKER_CONTAINERS enabled but docker not found"
+            errors=$((errors + 1))
+        else
+            echo "  ON:   DOCKER_CONTAINERS (${CRITICAL_CONTAINERS:-<empty>})"
+            enabled=$((enabled + 1))
+            # Verify listed containers exist
+            for c in ${CRITICAL_CONTAINERS:-}; do
+                if docker inspect "$c" &>/dev/null; then
+                    echo "        ✓ $c exists"
+                else
+                    echo "        ✗ $c not found (will alert as CRITICAL)"
+                    warnings=$((warnings + 1))
+                fi
+            done
+        fi
+    else
+        echo "  OFF:  DOCKER_CONTAINERS"
+    fi
+    
+    if [[ "${ENABLE_PM2_PROCESSES:-false}" == "true" ]]; then
+        if ! command -v pm2 &>/dev/null; then
+            echo "  WARN: PM2_PROCESSES enabled but pm2 not found"
+            warnings=$((warnings + 1))
+        else
+            echo "  ON:   PM2_PROCESSES (${CRITICAL_PM2_PROCESSES:-<empty>})"
+            enabled=$((enabled + 1))
+        fi
+    else
+        echo "  OFF:  PM2_PROCESSES"
+    fi
+    
+    if [[ "${ENABLE_SITE_MONITOR:-false}" == "true" ]]; then
+        echo "  ON:   SITE_MONITOR"
+        enabled=$((enabled + 1))
+        for site in ${CRITICAL_SITES:-}; do
+            local url="${site%%|*}"
+            echo "        → $url"
+        done
+    else
+        echo "  OFF:  SITE_MONITOR"
+    fi
+    
+    if [[ "${ENABLE_NVME_CHECK:-false}" == "true" ]]; then
+        if ! command -v smartctl &>/dev/null; then
+            echo "  WARN: NVME_CHECK enabled but smartctl not found"
+            warnings=$((warnings + 1))
+        else
+            echo "  ON:   NVME_CHECK (${NVME_DEVICE:-/dev/nvme0n1})"
+            enabled=$((enabled + 1))
+        fi
+    else
+        echo "  OFF:  NVME_CHECK"
+    fi
+    
+    # Threshold validation
+    echo ""
+    echo "[Thresholds]"
+    validate_thresholds 2>&1 | grep -v "Monitor run" || echo "  All thresholds valid."
+    
+    # Summary
+    echo ""
+    echo "================================="
+    echo "Checks enabled: $enabled"
+    echo "Errors: $errors | Warnings: $warnings"
+    if [[ $errors -gt 0 ]]; then
+        echo "STATUS: FAIL — fix errors above before running"
+        return 1
+    elif [[ $warnings -gt 0 ]]; then
+        echo "STATUS: OK (with warnings)"
+        return 0
+    else
+        echo "STATUS: OK"
+        return 0
+    fi
+}
+
+run_test() {
+    echo "Telemon test mode"
+    echo "================="
+    echo ""
+    
+    # Validate first
+    if ! run_validate; then
+        echo ""
+        echo "Fix validation errors before testing."
+        return 1
+    fi
+    
+    echo ""
+    echo "[Telegram Connectivity Test]"
+    echo "  Sending test message..."
+    
+    local test_msg="<b>&#128421; [$(hostname)] Telemon Test</b>%0A"
+    test_msg+="<i>$(date '+%Y-%m-%d %H:%M:%S %Z')</i>%0A%0A"
+    test_msg+="&#9989; Configuration is valid. Telegram delivery works.%0A"
+    test_msg+="This is a test message from <code>telemon.sh --test</code>."
+    
+    if send_telegram "$test_msg"; then
+        echo "  OK: Test message sent — check your Telegram!"
+        return 0
+    else
+        echo "  FAIL: Could not send message. Check bot token and chat ID."
+        return 1
+    fi
+}
+
+# ===========================================================================
 # Telegram Dispatch
 # ===========================================================================
 send_telegram() {
@@ -969,6 +1150,29 @@ send_telegram() {
 # Main
 # ===========================================================================
 main() {
+    # Handle CLI flags
+    case "${1:-}" in
+        --test|-t)
+            run_test
+            exit $?
+            ;;
+        --validate|-v)
+            run_validate
+            exit $?
+            ;;
+        --help|-h)
+            echo "Usage: telemon.sh [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --test, -t       Validate config and send a test Telegram message"
+            echo "  --validate, -v   Validate configuration without sending anything"
+            echo "  --help, -h       Show this help"
+            echo ""
+            echo "With no options, runs a full monitoring check cycle."
+            exit 0
+            ;;
+    esac
+    
     log "INFO" "--- Monitor run started ---"
     
     # Validate configuration thresholds


### PR DESCRIPTION
## Summary

Improvements based on real-world onboarding experience — making first-time setup faster, safer, and less confusing.

## Changes

### `telemon.sh` — New CLI flags
- `--test` / `-t`: validates config + sends a test Telegram message (replaces guessing if your bot works)
- `--validate` / `-v`: checks credentials, .env permissions, dependencies, container existence — without sending anything
- `--help` / `-h`: usage info

### `install.sh` — Non-interactive mode + security
- `--yes` / `-y` flag: skips the "Run test now?" prompt for CI, scripting, and automation
- Auto-sets `.env` to `chmod 600` after validation — prevents world-readable bot tokens

### `.env.example` — Container name clarification
- Clarified that `CRITICAL_CONTAINERS` expects container **names** (from `docker ps --format '{{.Names}}'`), not image names
- Fixed repo URL reference

### `README.md` — Quickstart profiles
- Added "Common Configurations" section with 5 copy-paste `.env` snippets:
  - Docker Host, Web Server, Media Server, Bare Metal/VPS, Node.js App Server
- Updated Manual Operations with `--validate` and `--test` docs
- Updated troubleshooting table to reference new CLI flags

### `CHANGELOG.md`
- Documented all changes under `[Unreleased]`
- Fixed repo URLs (were `yourusername`, now `SwordfishTrumpet`)

## Testing
- `telemon.sh --help` ✅
- `telemon.sh --validate` ✅ (11 checks, 0 errors, 0 warnings)
- `telemon.sh --test` ✅ (Telegram message delivered)
- `telemon.sh` (normal run) ✅ (no regressions)